### PR TITLE
[Fix]Doorkeeper APIエンドポイントのスキーマ部をhttpからhttpsに変更

### DIFF
--- a/js/doorkeeper.js
+++ b/js/doorkeeper.js
@@ -1,7 +1,7 @@
 // doorkeeper API Ajax用オブジェクト
 doorkeeperApi = {
   type: "GET",
-  url: 'http://api.doorkeeper.jp/groups/hmrb/events',
+  url: 'https://api.doorkeeper.jp/groups/hmrb/events',
   dataType: "jsonp",
   cache: false,
   timeout: 5000,


### PR DESCRIPTION
# 概要
Close #21 

# 確認方法
- ローカルで起動し、Doorkeeperのスケジュールが読み込めることを確認する。
